### PR TITLE
fix: ajustar listagem de unidades para exibir todas sem paginação

### DIFF
--- a/inventory_management/templates/product_unit_list.html
+++ b/inventory_management/templates/product_unit_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load query_transform %}
 {% load iam_tags static %}
 {% block extra_styles %}
 {{ form.media.css }}
@@ -155,45 +154,6 @@
         </div>
         {% endif %}
     </div>
-    {% if page_obj.paginator.num_pages > 1 %}
-    <div class="row justify-content-center mt-4">
-        <nav aria-label="Page navigation">
-            <ul class="pagination">
-                {% if page_obj.has_previous %}
-                <li class="page-item">
-                    <a class="page-link" href="?{% query_transform request page=1 %}">Primeira</a>
-                </li>
-                <li class="page-item">
-                    <a class="page-link"
-                        href="?{% query_transform request page=page_obj.previous_page_number %}">Anterior</a>
-                </li>
-                {% endif %}
-
-                {% for num in page_obj.paginator.page_range %}
-                {% if page_obj.number == num %}
-                <li class="page-item active">
-                    <a class="page-link" href="?{% query_transform request page=num %}">{{ num }}</a>
-                </li>
-                {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %} <li class="page-item">
-                    <a class="page-link" href="?{% query_transform request page=num %}">{{ num }}</a>
-                    </li>
-                    {% endif %}
-                    {% endfor %}
-
-                    {% if page_obj.has_next %}
-                    <li class="page-item">
-                        <a class="page-link"
-                            href="?{% query_transform request page=page_obj.next_page_number %}">Próxima</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link"
-                            href="?{% query_transform request page=page_obj.paginator.num_pages %}">Última</a>
-                    </li>
-                    {% endif %}
-            </ul>
-        </nav>
-    </div>
-    {% endif %}
 </div>
 {% endblock %}
 {% block extra_scripts %}

--- a/inventory_management/templates/product_unit_list.html
+++ b/inventory_management/templates/product_unit_list.html
@@ -33,6 +33,14 @@
                     <option value="nao" {% if request.GET.filter_baixado == "nao" %}selected{% endif %}>Não</option>
                 </select>
             </div>
+            <div class="col-md-6 mb-3">
+                <label for="page_size">Itens por página</label>
+                <select name="page_size" id="page_size" class="form-select">
+                    {% for option in page_size_options %}
+                    <option value="{{ option }}" {% if option == current_page_size %}selected{% endif %}>{{ option }}</option>
+                    {% endfor %}
+                </select>
+            </div>
         </div>
         <div class="row justify-content-center mt-3">
             <div class="col-md-3 text-center">
@@ -147,6 +155,35 @@
                     </tbody>
                 </table>
             </form>
+            {% if is_paginated %}
+            <nav aria-label="Paginação de unidades" class="mt-3">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+                        {% if page_obj.has_previous %}
+                        <a class="page-link" href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" aria-label="Anterior">Anterior</a>
+                        {% else %}
+                        <span class="page-link">Anterior</span>
+                        {% endif %}
+                    </li>
+                    {% for num in paginator.page_range %}
+                    <li class="page-item {% if page_obj.number == num %}active{% endif %}">
+                        {% if page_obj.number == num %}
+                        <span class="page-link">{{ num }}</span>
+                        {% else %}
+                        <a class="page-link" href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ num }}">{{ num }}</a>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                    <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+                        {% if page_obj.has_next %}
+                        <a class="page-link" href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" aria-label="Próxima">Próxima</a>
+                        {% else %}
+                        <span class="page-link">Próxima</span>
+                        {% endif %}
+                    </li>
+                </ul>
+            </nav>
+            {% endif %}
         </div>
         {% else %}
         <div class="col-12">
@@ -165,6 +202,13 @@
         const checkboxes = document.querySelectorAll('input[name="selected_items"]');
         checkboxes.forEach(checkbox => {
             checkbox.checked = selectAllCheckbox.checked;
+        });
+    }
+
+    const pageSizeSelect = document.getElementById('page_size');
+    if (pageSizeSelect) {
+        pageSizeSelect.addEventListener('change', function () {
+            document.getElementById('filter_form').submit();
         });
     }
 </script>

--- a/inventory_management/views.py
+++ b/inventory_management/views.py
@@ -1372,7 +1372,22 @@ class ProductUnitListView(LoginRequiredMixin, ListView):
     model = ProductUnit
     template_name = 'product_unit_list.html'
     context_object_name = 'product_units'
-    paginate_by = 10
+
+    def get_paginate_by(self, queryset):
+        page_size = self.request.GET.get('page_size')
+        total_items = queryset.count()
+
+        if page_size:
+            if page_size.lower() == 'all':
+                return total_items or None
+            try:
+                size = int(page_size)
+                if size > 0:
+                    return size
+            except ValueError:
+                pass
+
+        return total_items or None
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/inventory_management/views.py
+++ b/inventory_management/views.py
@@ -1372,22 +1372,23 @@ class ProductUnitListView(LoginRequiredMixin, ListView):
     model = ProductUnit
     template_name = 'product_unit_list.html'
     context_object_name = 'product_units'
+    paginate_by = 10
+    page_size_options = [10, 20, 50, 100]
 
     def get_paginate_by(self, queryset):
         page_size = self.request.GET.get('page_size')
-        total_items = queryset.count()
 
         if page_size:
-            if page_size.lower() == 'all':
-                return total_items or None
             try:
                 size = int(page_size)
-                if size > 0:
-                    return size
-            except ValueError:
-                pass
+            except (TypeError, ValueError):
+                size = self.paginate_by
+            else:
+                if size not in self.page_size_options:
+                    size = self.paginate_by
+            self.paginate_by = size
 
-        return total_items or None
+        return self.paginate_by
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -1422,6 +1423,11 @@ class ProductUnitListView(LoginRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
         context['form'] = FilterProductUnitForm(self.request.GET or None)
         context['locations'] = StorageType.objects.exclude(name__in=["Baixa"])
+        params = self.request.GET.copy()
+        params.pop('page', None)
+        context['query_string'] = params.urlencode()
+        context['current_page_size'] = self.paginate_by
+        context['page_size_options'] = self.page_size_options
         return context
 
 class ProductAutoComplete(View):


### PR DESCRIPTION
- paginate_by calculado dinamicamente em ProductUnitListView
- removido bloco de paginação em product_unit_list.html
- todas as unidades agora ficam disponíveis para seleção de QR Codes